### PR TITLE
Add stick to orient rails

### DIFF
--- a/src/com/github/xericore/easycarts/EasyCarts.java
+++ b/src/com/github/xericore/easycarts/EasyCarts.java
@@ -23,6 +23,7 @@ public class EasyCarts extends JavaPlugin
 	public final EasyCartsListener myMinecartListener = new EasyCartsListener(this);
 	public final PlayerClickListener myPlayerClickListener = new PlayerClickListener(this);
 	public final MyVehicleCollisionListener myVehicleCollisionListener = new MyVehicleCollisionListener(this);
+	public final PlayerRailInteractListener myPlayerRailInteractListener = new PlayerRailInteractListener(this);
 
 	public void onEnable()
 	{
@@ -38,6 +39,7 @@ public class EasyCarts extends JavaPlugin
 	{
 		getServer().getPluginManager().registerEvents(this.myMinecartListener, this);
 		getServer().getPluginManager().registerEvents(this.myVehicleCollisionListener, this);
+		getServer().getPluginManager().registerEvents(this.myPlayerRailInteractListener, this);
 
 		if (getConfig().getBoolean("StopStartOnLeftClick"))
 			getServer().getPluginManager().registerEvents(this.myPlayerClickListener, this);

--- a/src/com/github/xericore/easycarts/PlayerRailInteractListener.java
+++ b/src/com/github/xericore/easycarts/PlayerRailInteractListener.java
@@ -1,0 +1,43 @@
+package com.github.xericore.easycarts;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Vehicle;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.block.data.Rail;
+import org.bukkit.util.Vector;
+
+/**
+ * Class to re-orient rails when right clicked by a stick
+ * @author crazygmr101
+ */
+public class PlayerRailInteractListener implements Listener
+{
+
+	public static EasyCarts easyCartsPlugin;
+	private static FileConfiguration config = null;
+
+	public PlayerRailInteractListener(EasyCarts theInstance)
+	{
+		easyCartsPlugin = theInstance;
+		config = easyCartsPlugin.getConfig();
+	}
+
+	@EventHandler(priority=EventPriority.HIGH)
+	public void onPlayerUse(PlayerInteractEvent event){
+		if (!Utils.isRail(event.getClickedBlock().getType())) return;
+		if (event.getItem() == null) return;
+		if (event.getItem().getType() != Material.STICK) return;
+		Block block = event.getClickedBlock();
+		block.setBlockData(
+				(BlockData)Utils.changeRailDirection((Rail)event.getClickedBlock().getBlockData(), event.getPlayer().isSneaking())
+		);
+	}
+}

--- a/src/com/github/xericore/easycarts/Utils.java
+++ b/src/com/github/xericore/easycarts/Utils.java
@@ -1,11 +1,13 @@
 package com.github.xericore.easycarts;
 
 import java.util.List;
+import java.util.Set;
 
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.Rail;
 import org.bukkit.entity.*;
 import org.bukkit.entity.minecart.RideableMinecart;
 import org.bukkit.event.vehicle.VehicleMoveEvent;
@@ -266,5 +268,25 @@ class Utils
 				}
 			}
 		}
+	}
+
+	static boolean isRail(Material m) {
+		return m == Material.RAIL ||
+			   	m == Material.POWERED_RAIL ||
+				m == Material.ACTIVATOR_RAIL ||
+				m == Material.DETECTOR_RAIL;
+	}
+
+	static Rail changeRailDirection(Rail r, boolean b) {
+		Set<Rail.Shape> shapes = r.getShapes();
+		Rail.Shape[] array = new Rail.Shape[shapes.size()];
+		shapes.toArray(array);
+		int i;
+		for (i = 0; i < array.length; i++)
+			if (r.getShape().equals(array[i]))
+				break;
+		System.out.println(i);
+		r.setShape(array[(i+(b ? 1 : -1)+array.length)%array.length]);
+		return r;
 	}
 }


### PR DESCRIPTION
Added stick to orient rails, similar to how the debug stick works. Right click to cycle through rail orientations, and shift right click to cycle backwards.